### PR TITLE
fix lr-lb dnat with multiple distributed gateway ports for ovn 24.03

### DIFF
--- a/northd/northd.c
+++ b/northd/northd.c
@@ -11334,6 +11334,19 @@ build_distr_lrouter_nat_flows_for_lb(struct lrouter_nat_lb_flows_ctx *ctx,
 {
     struct ovn_port *dgp = od->l3dgw_ports[0];
 
+    if (od->n_l3dgw_ports > 1)
+    {
+        const char *vip = ctx->lb_vip->vip_str;
+        for (size_t j = 0; j < od->n_l3dgw_ports; j++)
+        {
+            if (find_lrp_member_ip(od->l3dgw_ports[j], vip))
+            {
+                dgp = od->l3dgw_ports[j];
+                break;
+            }
+        }
+    }
+
     const char *undnat_action;
 
     switch (type) {
@@ -11364,7 +11377,7 @@ build_distr_lrouter_nat_flows_for_lb(struct lrouter_nat_lb_flows_ctx *ctx,
 
     if (ctx->lb_vip->n_backends || !ctx->lb_vip->empty_backend_rej) {
         ds_put_format(ctx->new_match, " && is_chassis_resident(%s)",
-                      od->l3dgw_ports[0]->cr_port->json_key);
+                      dgp->cr_port->json_key);
     }
 
     ovn_lflow_add_with_hint__(ctx->lflows, od, S_ROUTER_IN_DNAT, ctx->prio,

--- a/northd/northd.c
+++ b/northd/northd.c
@@ -11363,20 +11363,8 @@ build_distr_lrouter_nat_flows_for_lb(struct lrouter_nat_lb_flows_ctx *ctx,
     }
 
     if (ctx->lb_vip->n_backends || !ctx->lb_vip->empty_backend_rej) {
-        if (od->n_l3dgw_ports > 1) {
-            for (size_t i = 0; i < od->n_l3dgw_ports; i++) {
-                const char *vip = ctx->lb_vip->vip_str;
-                if (find_lrp_member_ip(od->l3dgw_ports[i], vip)) {
-                    ds_put_format(ctx->new_match,
-                                  " && is_chassis_resident(%s)",
-                                  od->l3dgw_ports[i]->cr_port->json_key);
-                    break;
-                }
-            }
-        } else {
-            ds_put_format(ctx->new_match, " && is_chassis_resident(%s)",
-                          od->l3dgw_ports[0]->cr_port->json_key);
-        }
+        ds_put_format(ctx->new_match, " && is_chassis_resident(%s)",
+                      od->l3dgw_ports[0]->cr_port->json_key);
     }
 
     ovn_lflow_add_with_hint__(ctx->lflows, od, S_ROUTER_IN_DNAT, ctx->prio,


### PR DESCRIPTION
https://github.com/kubeovn/kube-ovn/issues/3329

ovn 24.03 较 22.12 在这部分代码进行了重构，因此这个bug需要重新修复